### PR TITLE
Add GIF_URL as an output to the step's definition (step.yml)

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -28,3 +28,10 @@ inputs:
         The default is "such wow,awesome,shipit,yes,panda,cat,hell yeah,applaud,lgtm,surprise,suprise motherfucker,yeah bitches,high five,legendary,lil bub"
       is_expand: false
       is_required: true
+outputs:
+  - GIF_URL:
+    opts:
+      title: "GIF URL"
+      summary: "Generated GIF (https://giphy.com/) URL."
+      description: "Generated GIF (https://giphy.com/) URL."
+      is_expand: false


### PR DESCRIPTION
`outputs` listed in the `step.yml` are presented on the UI, e.g. the workflow editor.
Currently on the web UI this step is listed as it does not have any outputs - this PR fixes that.